### PR TITLE
TODO-34 Get all tasks from api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 
 		<!-- JPA (Hibernate included) -->
 		<dependency>

--- a/src/main/java/pl/common/todo/api/ToDoApi/WebSecurityConfig.java
+++ b/src/main/java/pl/common/todo/api/ToDoApi/WebSecurityConfig.java
@@ -1,0 +1,17 @@
+package pl.common.todo.api.ToDoApi;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.web.cors.CorsConfiguration;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues());
+	}
+}


### PR DESCRIPTION
Front próbował skorzystać z endpointu localhost:6969/tasks, ale nie mógł, bo aplikacja backendowa (czytaj Api) zwracała, że nie ma dostępu. Dzieje się tak, ponieważ domyślnie nasza aplikacja jest zabezpieczona przed "atakami" innych aplikacji. Przeglądarki nie mają problemu, aby się tam dostać, ale wszystko inne już ma problem. Te zabezpieczenia nazywają się `CORS`. Poniżej przekonfigurowałem te CORSy, tak aby każda aplikacja mogła strzelać do naszego Api i za pomocą `GET`, `POST`, `DELETE`. Cała reszta jest zabroniona.