### PR TITLE
TODO-35

### DIFF
--- a/src/main/java/pl/common/todo/api/ToDoApi/config/WebSecurityConfig.java
+++ b/src/main/java/pl/common/todo/api/ToDoApi/config/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package pl.common.todo.api.ToDoApi.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -12,7 +13,13 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
-		http.cors().configurationSource(request -> new CorsConfiguration().applyPermitDefaultValues()).and().csrf()
-				.disable();
+		CorsConfiguration corsConfiguration = new CorsConfiguration();
+		corsConfiguration.addAllowedOrigin(CorsConfiguration.ALL);
+		corsConfiguration.addAllowedHeader(CorsConfiguration.ALL);
+		corsConfiguration.addAllowedMethod(HttpMethod.GET.name());
+		corsConfiguration.addAllowedMethod(HttpMethod.POST.name());
+		corsConfiguration.addAllowedMethod(HttpMethod.DELETE.name());
+
+		http.cors().configurationSource(request -> new CorsConfiguration(corsConfiguration)).and().csrf().disable();
 	}
 }

--- a/src/main/java/pl/common/todo/api/ToDoApi/config/WebSecurityConfig.java
+++ b/src/main/java/pl/common/todo/api/ToDoApi/config/WebSecurityConfig.java
@@ -19,6 +19,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		corsConfiguration.addAllowedMethod(HttpMethod.GET.name());
 		corsConfiguration.addAllowedMethod(HttpMethod.POST.name());
 		corsConfiguration.addAllowedMethod(HttpMethod.DELETE.name());
+		corsConfiguration.addAllowedMethod(HttpMethod.PUT.name());
 
 		http.cors().configurationSource(request -> new CorsConfiguration(corsConfiguration)).and().csrf().disable();
 	}


### PR DESCRIPTION
Kiedy myślisz, że już nic nie trzeba będzie konfigurować, to okazuje się, że jednak o czymś zapomniałeś :P 
Wcześniej korzystaliśmy z `new CorsConfiguration().applyPermitDefaultValues()`. Czyli braliśmy domyślną konfigurację spring boota, która pozwalała na metody: POST, PUT, GET. W tym zadaniu musiałem dodać usuwanie rekordów za pomocą metody DELETE. Nie trudno się domyślić, że API odbijało metodę delete przez tą konfigurację.
Teraz nie korzystam z domyślnej konfiguracji, zamiast tego sam ją napisałem dobraną do naszych potrzeb. Swoją drogą, jestem ciekawy czy znajdziesz bug'a w tym zadaniu, bo jest :) (Podpowiedź, myśli co masz jeszcze do zrobienia po stronie API, może uda Ci dowiedzieć o czym zapomniałem w tym kodzie :) )